### PR TITLE
comecar com vermelho a primeira marca do sinal

### DIFF
--- a/Traffic_light_signal.c
+++ b/Traffic_light_signal.c
@@ -15,7 +15,7 @@ typedef enum {
 } traffic_light_state_t;
 
 // Variáveis globais
-volatile traffic_light_state_t current_state = STATE_RED;
+volatile traffic_light_state_t current_state = STATE_GREEN;
 volatile bool timer_callback_called = false;
 
 // Função de callback do temporizador


### PR DESCRIPTION
O sinal estava começando com amarelo, correção para começar no vermelho